### PR TITLE
Fix crimson/warped supports

### DIFF
--- a/resources/woods.py
+++ b/resources/woods.py
@@ -402,7 +402,7 @@ def generate(rm: ResourceManager):
         rm.block_and_item_tag('scribing_tables', item('scribing_table'))
         rm.block_and_item_tag('jar_shelves', item('jar_shelf'))
         rm.block_and_item_tag('water_wheels', item('water_wheel'))
-        rm.block_tag('support_beams', item('vertical_support'), item('horizontal_support'))
+        rm.block_tag('tfc:support_beams', item('vertical_support'), item('horizontal_support'))
 
         rm.item_tag('axles', item('axle'), item('encased_axle'))
         rm.item_tag('gear_boxes', item('gear_box'))


### PR DESCRIPTION
Currently crimson and warped supports get added to the `#beneath:support_beam` and the `#beneath:support_beams` tag. The latter seems to be a typo. They need to get added to the `tfc:support_beams` tag to work properly, right now they refuse to make horizontal beams.